### PR TITLE
Add SEO meta description tag in settings and in application layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title><%= Settings.site_title %></title>
-    <meta name="description" content="<%= Settings.seo_description %>">
+    <meta name="description" content="<%= Settings.brief_explanation %>">
     <%= csrf_meta_tags %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon.png">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title><%= Settings.site_title %></title>
+    <meta name="description" content="<%= Settings.seo_description %>">
     <%= csrf_meta_tags %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon.png">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,3 +35,4 @@ tweet_messages:
   - 'Precisa ligar pro @santander_br pra resolver algo? Se prepare pra esperar 20 minutos pra ser atendido'
   - 'Aquela promessa de resolver tudo pelo app do @santander_br é só promessa mesmo...'
 google_analytics:
+seo_description: O Santander já me fez perder dezenas de horas da minha vida com seu péssimo serviço e atendimento ao consumidor. Queremos fazer algo sobre isso.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,4 +35,3 @@ tweet_messages:
   - 'Precisa ligar pro @santander_br pra resolver algo? Se prepare pra esperar 20 minutos pra ser atendido'
   - 'Aquela promessa de resolver tudo pelo app do @santander_br é só promessa mesmo...'
 google_analytics:
-seo_description: O Santander já me fez perder dezenas de horas da minha vida com seu péssimo serviço e atendimento ao consumidor. Queremos fazer algo sobre isso.


### PR DESCRIPTION
Contributes to #15 

This PR simply adds the meta description tag, and allows users to modify it in configuration (`Settings.seo_description`). 

We should still research keywords so that we can put them in the meta description, but I don't know Portuguese so I trouble researching in the Google Keyword Planner. Sorry! Still, I thought this was an important contribution before this was deployed.

Let me know what you think.